### PR TITLE
Проект по Java #2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,1 @@
+// dev branch for Y.Practicum

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
@@ -1,0 +1,26 @@
+package ru.yandex.practicum.contacts.presentation.base;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.DiffUtil;
+
+
+public class BaseListDiffCallback <T extends ListDiffInterface<T>> extends DiffUtil.ItemCallback<T>  {
+
+    @Override
+    public boolean areItemsTheSame(@NonNull T  oldItem, @NonNull T  newItem) {
+        return oldItem.theSameAs(newItem);
+    }
+
+    @Override
+    public boolean areContentsTheSame(@NonNull T  oldItem, @NonNull T  newItem) {
+        return oldItem.theSameAs(newItem);
+    }
+
+    @Nullable
+    @Override
+    public Object getChangePayload(@NonNull T  oldItem, @NonNull T  newItem) {
+        return oldItem.theSameAs(newItem);
+    }
+
+}

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
@@ -14,13 +14,13 @@ public class BaseListDiffCallback <T extends ListDiffInterface<T>> extends DiffU
 
     @Override
     public boolean areContentsTheSame(@NonNull T  oldItem, @NonNull T  newItem) {
-        return oldItem.theSameAs(newItem);
+        return oldItem.equals(newItem); //вернул исходные методы, которые в первый раз второпях потёр
     }
 
     @Nullable
     @Override
     public Object getChangePayload(@NonNull T  oldItem, @NonNull T  newItem) {
-        return oldItem.theSameAs(newItem);
+        return newItem; //вернул исходные методы, которые в первый раз второпях потёр
     }
 
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
@@ -1,0 +1,7 @@
+package ru.yandex.practicum.contacts.presentation.base;
+
+public interface ListDiffInterface<T> {
+    boolean theSameAs(T o);
+
+    boolean equals(Object o);
+}

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
@@ -1,7 +1,7 @@
 package ru.yandex.practicum.contacts.presentation.base;
 
 public interface ListDiffInterface<T> {
-    boolean theSameAs(T o);
+    boolean theSameAs(T newItem); //по совету поправил o на newItem для читаемости, спасибо
 
     boolean equals(Object o);
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
@@ -5,11 +5,9 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.AdapterListUpdateCallback;
 import androidx.recyclerview.widget.AsyncDifferConfig;
 import androidx.recyclerview.widget.AsyncListDiffer;
-import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
@@ -17,6 +15,7 @@ import java.util.function.Consumer;
 
 import ru.yandex.practicum.contacts.databinding.ItemFilterBinding;
 import ru.yandex.practicum.contacts.model.ContactType;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 import ru.yandex.practicum.contacts.presentation.filter.model.FilterContactType;
 import ru.yandex.practicum.contacts.presentation.filter.model.FilterContactTypeUi;
 import ru.yandex.practicum.contacts.utils.model.ContactTypeUtils;
@@ -26,7 +25,7 @@ public class FilterContactTypeAdapter extends RecyclerView.Adapter<FilterContact
 
     private final AsyncListDiffer<FilterContactTypeUi> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback<FilterContactTypeUi>()).build()
     );
 
     private final Consumer<FilterContactTypeUi> clickListener;
@@ -86,22 +85,4 @@ public class FilterContactTypeAdapter extends RecyclerView.Adapter<FilterContact
         }
     }
 
-    static class ListDiffCallback extends DiffUtil.ItemCallback<FilterContactTypeUi> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return oldItem.getContactType() == newItem.getContactType();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return newItem;
-        }
-    }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/model/FilterContactTypeUi.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/model/FilterContactTypeUi.java
@@ -2,7 +2,9 @@ package ru.yandex.practicum.contacts.presentation.filter.model;
 
 import androidx.annotation.NonNull;
 
-public class FilterContactTypeUi {
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
+
+public class FilterContactTypeUi implements ListDiffInterface<FilterContactTypeUi> {
 
     private final FilterContactType contactType;
     private final boolean selected;
@@ -18,6 +20,11 @@ public class FilterContactTypeUi {
 
     public boolean isSelected() {
         return selected;
+    }
+
+    @Override
+    public boolean theSameAs(@NonNull FilterContactTypeUi  o) {
+        return this.getContactType() == o.getContactType();
     }
 
     @Override

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
@@ -8,12 +8,10 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.AdapterListUpdateCallback;
 import androidx.recyclerview.widget.AsyncDifferConfig;
 import androidx.recyclerview.widget.AsyncListDiffer;
-import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
@@ -23,12 +21,13 @@ import java.util.Objects;
 
 import ru.yandex.practicum.contacts.R;
 import ru.yandex.practicum.contacts.databinding.ItemContactBinding;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 
 public class ContactAdapter extends RecyclerView.Adapter<ContactAdapter.ViewHolder> {
 
     private final AsyncListDiffer<ContactUi> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback<ContactUi>()).build()
     );
 
     @NonNull
@@ -93,22 +92,4 @@ public class ContactAdapter extends RecyclerView.Adapter<ContactAdapter.ViewHold
         }
     }
 
-    static class ListDiffCallback extends DiffUtil.ItemCallback<ContactUi> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return oldItem.hashCode() == newItem.hashCode();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return newItem;
-        }
-    }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactUi.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactUi.java
@@ -5,8 +5,9 @@ import androidx.annotation.NonNull;
 import java.util.List;
 
 import ru.yandex.practicum.contacts.model.ContactType;
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
 
-public class ContactUi {
+public class ContactUi implements ListDiffInterface<ContactUi> {
 
     private final String name;
     private final String phone;
@@ -39,6 +40,11 @@ public class ContactUi {
 
     public List<ContactType> getTypes() {
         return types;
+    }
+
+    @Override
+    public boolean theSameAs(@NonNull ContactUi o) {
+        return this.hashCode() == o.hashCode();
     }
 
     @Override

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
@@ -5,11 +5,9 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.AdapterListUpdateCallback;
 import androidx.recyclerview.widget.AsyncDifferConfig;
 import androidx.recyclerview.widget.AsyncListDiffer;
-import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
@@ -17,13 +15,14 @@ import java.util.function.Consumer;
 
 import ru.yandex.practicum.contacts.R;
 import ru.yandex.practicum.contacts.databinding.ItemSortBinding;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 import ru.yandex.practicum.contacts.presentation.sort.model.SortType;
 
 public class SortTypeAdapter extends RecyclerView.Adapter<SortTypeAdapter.ViewHolder> {
 
     private final AsyncListDiffer<SortTypeUI> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback<SortTypeUI>()).build()
     );
 
     private final Consumer<SortTypeUI> clickListener;
@@ -89,22 +88,4 @@ public class SortTypeAdapter extends RecyclerView.Adapter<SortTypeAdapter.ViewHo
         }
     }
 
-    static class ListDiffCallback extends DiffUtil.ItemCallback<SortTypeUI> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return oldItem.getSortType() == newItem.getSortType();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return newItem;
-        }
-    }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeUI.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeUI.java
@@ -2,9 +2,10 @@ package ru.yandex.practicum.contacts.presentation.sort;
 
 import androidx.annotation.NonNull;
 
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
 import ru.yandex.practicum.contacts.presentation.sort.model.SortType;
 
-public class SortTypeUI {
+public class SortTypeUI implements ListDiffInterface<SortTypeUI> {
 
     private final SortType sortType;
     private final boolean selected;
@@ -20,6 +21,11 @@ public class SortTypeUI {
 
     public boolean isSelected() {
         return selected;
+    }
+
+    @Override
+    public boolean theSameAs(@NonNull SortTypeUI o) {
+        return this.getSortType() == o.getSortType();
     }
 
     @Override
@@ -40,3 +46,4 @@ public class SortTypeUI {
         return result;
     }
 }
+


### PR DESCRIPTION
На setItems в ContactAdapter компилятор говорит что он тоже больше не нужен, нооо...
В задании про него ничего не написано и в 1:30 как-то опасаюсь трогать)
Если его нужно удалить - вернусь к этому по указанию из ревью, но прошу махнуть в теле теории что "Теперь вам больше не нужны классы ListDiffCallback и /используемые ими методы/ в каждом адаптере, от них можно избавиться" для следующих когорт.